### PR TITLE
Fix flipped coordinates in polyline en-/decoding

### DIFF
--- a/polyline/src/main/scala/com/free2move/geoscala/polyline.scala
+++ b/polyline/src/main/scala/com/free2move/geoscala/polyline.scala
@@ -43,7 +43,7 @@ object polyline {
   }
 
   private def coord2Poly(coord: Coordinate): String = {
-    num2Poly(coord.longitude) + num2Poly(coord.latitude)
+     num2Poly(coord.latitude) + num2Poly(coord.longitude)
   }
 
   private def num2Poly(num: Double): String = {
@@ -80,12 +80,12 @@ object polyline {
             .map {
               // it is safe to only match this case as it was checked above that the length is even
               // then every group has exactly 2 elements
-              case List(lng, lat) => Coordinate(lat, lng)
+              case List(lng, lat) => Coordinate(longitude = lng, latitude = lat)
             }
             .toList
             .scanRight(Coordinate(0.0, 0.0)) {
               case (old, delta) =>
-                Coordinate(old.longitude + delta.longitude, old.latitude + delta.latitude)
+                Coordinate(longitude = old.longitude + delta.longitude, latitude = old.latitude + delta.latitude)
             }
             .reverse
             .tail

--- a/polyline/src/test/scala/com/free2move/geoscala/PolylineTest.scala
+++ b/polyline/src/test/scala/com/free2move/geoscala/PolylineTest.scala
@@ -22,18 +22,18 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 class PolylineTest extends FlatSpec with Matchers with OptionValues with TryValues with ScalaCheckDrivenPropertyChecks {
 
   "The polyline encoding" should "be correct for the Google sample" in {
-    val example = LineString(List(Coordinate(38.5, -120.2), Coordinate(40.7, -120.95), Coordinate(43.252, -126.453)))
+    val example = LineString(List(Coordinate(longitude = -120.2, latitude = 38.5), Coordinate(longitude = -120.95, latitude = 40.7), Coordinate(longitude = -126.453, latitude = 43.252)))
     polyline.encode(example) shouldBe "_p~iF~ps|U_ulLnnqC_mqNvxq`@"
   }
 
   "The polyline decoding" should "be correct for the Google sample" in {
     val example = "_p~iF~ps|U_ulLnnqC_mqNvxq`@"
-    val expected = LineString(List(Coordinate(38.5, -120.2), Coordinate(40.7, -120.95), Coordinate(43.252, -126.453)))
+    val expected = LineString(List(Coordinate(longitude = -120.2, latitude = 38.5), Coordinate(longitude = -120.95, latitude = 40.7), Coordinate(longitude = -126.453, latitude = 43.252)))
     val result = polyline.decode(example)
     result.success.value shouldBe expected
   }
 
-  it should "handle an example Lime trip" in {
+  it should "handle an example trip through Warsaw" in {
     val poly =
       "q_|}Hu|f_C_@O?A@CW~@NxAMv@[r@e@r@e@n@Uh@En@CbAUv@Ut@_@b@]b@a@f@c@j@En@RzA^pAh@fAl@rBThAPz@RbAZ|ALn@Nz@Jf@^pAZlAf@pBTfBLbCFpAFfBDnAF|AF|AFbBHpBFvAHlBFpAHnBJjBDl@RzB"
     val decoded = polyline.decode(poly).success.value


### PR DESCRIPTION
Polyline has coordinates in latitude-longitude order (different to GeoJSON's longitude-latitude), our en-/decoding didn't respect that. As the sample values in tests were also flipped, it hasn't been noticed so far. This PR fixes the order and uses named parameters to avoid such mistakes in the future.