### PR TITLE
Add support for Scala 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ cache:
   directories:
   - "$HOME/.ivy2"
 scala:
-  - 2.12.8
-  - 2.11.12
+  - 2.13.0
+  - 2.12.10
 branches:
   only:
     - master
@@ -17,7 +17,7 @@ jobs:
     - stage: publish
       if: tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/
       scala:
-        - 2.12.8
+        - 2.13.0
       before_install:
         - openssl aes-256-cbc -K $encrypted_30b6cfe91504_key -iv $encrypted_30b6cfe91504_iv
           -in key.asc.enc -out key.asc -d

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.free2move/geo-scala-core_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.free2move/geo-scala-core_2.12)
 [![Build Status](https://travis-ci.com/Free2MoveApp/geo-scala.svg?branch=master)](https://travis-ci.com/Free2MoveApp/geo-scala)
 
-A core AST and utilities for GeoJSON ([RFC 7946][rfc-7946]) and more.
+A core AST and utilities for GeoJSON ([RFC 7946][rfc-7946]) and more. Builds for Scala 2.13 and 2.12.
 
 The project is divided in several submodules:
  - `core` contains the data model for geographical entities;

--- a/build.sbt
+++ b/build.sbt
@@ -1,17 +1,16 @@
-val scala211 = "2.11.12"
-val scala212 = "2.12.8"
-// val scala213 = "2.13.0-RC1"
+val scala212 = "2.12.10"
+val scala213 = "2.13.0"
 
 lazy val commonSettings = Seq(
-  scalaVersion := scala212,
-  crossScalaVersions := Seq(scala211, scala212),
+  scalaVersion := scala213,
+  crossScalaVersions := Seq(scala212, scala213),
   organization := "com.free2move",
   version := "0.1.2",
   licenses += ("The Apache Software License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")),
   homepage := Some(url("https://github.com/Free2MoveApp/geo-scala")),
   libraryDependencies ++= Seq(
-    "org.scalatest" %% "scalatest" % "3.2.0-SNAP10" % Test,
-    "org.scalatestplus" %% "scalatestplus-scalacheck" % "1.0.0-SNAP8" % Test,
+    "org.scalatest" %% "scalatest" % "3.1.0-RC2" % Test,
+    "org.scalatestplus" %% "scalatestplus-scalacheck" % "3.1.0.0-RC2" % Test,
     "org.scalacheck" %% "scalacheck" % "1.14.0" % Test),
 )
 
@@ -28,7 +27,7 @@ lazy val core = project.in(file("core"))
     name := "geo-scala-core"
   ))
 
-val circeVersion = "0.11.1"
+val circeVersion = "0.12.1"
 lazy val circe = project.in(file("circe"))
   .dependsOn(core)
   .settings(commonSettings ++ publishSettings ++ Seq(

--- a/circe/src/main/scala/com/free2move/geoscala/circe.scala
+++ b/circe/src/main/scala/com/free2move/geoscala/circe.scala
@@ -57,15 +57,15 @@ trait GeoJsonEncoders extends LowPriorityGeoJsonEncoders {
     case mp: MultiPolygon     => mp.asJson
   }
 
-  implicit def extendedFeatureEncoder[Properties: ObjectEncoder]: Encoder[Feature[Properties]] = Encoder.instance { feature =>
+  implicit def extendedFeatureEncoder[Properties: Encoder.AsObject]: Encoder[Feature[Properties]] = Encoder.instance { feature =>
     Json.obj("type" := "Feature", "properties" := feature.properties, "geometry" := feature.geometry)
   }
 
-  implicit def extendedFeatureCollectionEncoder[Properties: ObjectEncoder]: Encoder[FeatureCollection[Properties]] = Encoder.instance { featureCollection =>
+  implicit def extendedFeatureCollectionEncoder[Properties: Encoder.AsObject]: Encoder[FeatureCollection[Properties]] = Encoder.instance { featureCollection =>
     Json.obj("type" := "FeatureCollection", "features" := featureCollection.features)
   }
 
-  implicit def geojsonEncoder[Properties: ObjectEncoder]: Encoder[GeoJson[Properties]] = Encoder.instance {
+  implicit def geojsonEncoder[Properties: Encoder.AsObject]: Encoder[GeoJson[Properties]] = Encoder.instance {
     case fc @ FeatureCollection(_) => fc.asJson
     case f @ Feature(_, _)         => f.asJson
     case geom: Geometry            => (geom: Geometry).asJson

--- a/circe/src/test/scala/com/free2move/geoscala/CirceDecodingTests.scala
+++ b/circe/src/test/scala/com/free2move/geoscala/CirceDecodingTests.scala
@@ -17,9 +17,11 @@ package com.free2move.geoscala
 
 import io.circe._
 import io.circe.syntax._
-import org.scalatest.{EitherValues, FlatSpec, Matchers}
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CirceDecodingTests extends FlatSpec with Matchers with EitherValues {
+class CirceDecodingTests extends AnyFlatSpec with Matchers with EitherValues {
 
   import com.free2move.geoscala.circe._
 

--- a/core/src/test/scala/com/free2move/geoscala/AreaTest.scala
+++ b/core/src/test/scala/com/free2move/geoscala/AreaTest.scala
@@ -16,10 +16,11 @@
 package com.free2move.geoscala
 
 import org.scalatest._
-
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import ops._
 
-class AreaTest extends FlatSpec with Matchers with OptionValues {
+class AreaTest extends AnyFlatSpec with Matchers with OptionValues {
 
   "The area" should "be correct for a square" in {
     val poly = Polygon(List(List(Coordinate(-121, 39), Coordinate(-119, 39), Coordinate(-119, 41), Coordinate(-121, 41), Coordinate(-121, 39))))

--- a/core/src/test/scala/com/free2move/geoscala/EnvelopeTest.scala
+++ b/core/src/test/scala/com/free2move/geoscala/EnvelopeTest.scala
@@ -16,15 +16,16 @@
 package com.free2move.geoscala
 
 import org.scalatest._
-
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import ops._
 
-class EnvelopeTest extends FlatSpec with Matchers with OptionValues {
+class EnvelopeTest extends AnyFlatSpec with Matchers with OptionValues {
 
   "The envelope" should "be the bounding box for a polygon" in {
     val poly = Polygon(List(List(Coordinate(-121, 39), Coordinate(-119, 39), Coordinate(-119, 41), Coordinate(-121, 41), Coordinate(-121, 39))))
     val envelope = Polygon(List(List(Coordinate(-121, 39), Coordinate(-121, 41), Coordinate(-119, 41), Coordinate(-119, 39), Coordinate(-121, 39))))
-    poly.envelope shouldBe 'defined
+    poly.envelope shouldBe defined
     poly.envelope.value shouldBe envelope
   }
 
@@ -36,14 +37,14 @@ class EnvelopeTest extends FlatSpec with Matchers with OptionValues {
       )
     )
     val envelope = Polygon(List(List(Coordinate(-121, 39), Coordinate(-121, 41), Coordinate(-119, 41), Coordinate(-119, 39), Coordinate(-121, 39))))
-    poly.envelope shouldBe 'defined
+    poly.envelope shouldBe defined
     poly.envelope.value shouldBe envelope
   }
 
   it should "be the bounding box including all parts of a multi polygon" in {
     val poly = MultiPolygon(List(List(List(Coordinate(-121, 39), Coordinate(-119, 39), Coordinate(-119, 41), Coordinate(-121, 41), Coordinate(-121, 39)))))
     val envelope = Polygon(List(List(Coordinate(-121, 39), Coordinate(-121, 41), Coordinate(-119, 41), Coordinate(-119, 39), Coordinate(-121, 39))))
-    poly.envelope shouldBe 'defined
+    poly.envelope shouldBe defined
     poly.envelope.value shouldBe envelope
   }
 

--- a/polyline/src/test/scala/com/free2move/geoscala/PolylineTest.scala
+++ b/polyline/src/test/scala/com/free2move/geoscala/PolylineTest.scala
@@ -18,9 +18,11 @@ package com.free2move.geoscala
 import org.scalacheck._
 import org.scalactic.{Equality, TolerantNumerics}
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class PolylineTest extends FlatSpec with Matchers with OptionValues with TryValues with ScalaCheckDrivenPropertyChecks {
+class PolylineTest extends AnyFlatSpec with Matchers with OptionValues with TryValues with ScalaCheckDrivenPropertyChecks {
 
   "The polyline encoding" should "be correct for the Google sample" in {
     val example = LineString(List(Coordinate(longitude = -120.2, latitude = 38.5), Coordinate(longitude = -120.95, latitude = 40.7), Coordinate(longitude = -126.453, latitude = 43.252)))


### PR DESCRIPTION
- drop 2.11 support
- circe 0.12.1
- updates for test deps
- resolve most 2.13 & circe deprecations (except for projections on `Either`, there doesn't seem to be a good way)